### PR TITLE
Init project with basic DevOps CI flow using pytest and .drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,13 @@
+name: default
+
+type: docker
+kind: pipeline
+
+steps:
+  - name: Build & Test
+    image: python:3-alpine
+    commands:
+      - pip install -r requirements.txt
+      - pytest
+    when:
+      - pull_request

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2020 Waterball (johnny850807@gmail.com)
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,14 @@
+#  Copyright 2020 Waterball (johnny850807@gmail.com)
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+

--- a/src/stub.py
+++ b/src/stub.py
@@ -1,0 +1,16 @@
+#  Copyright 2020 Waterball (johnny850807@gmail.com)
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+def add(a, b):
+    return a + b

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,14 @@
+#  Copyright 2020 Waterball (johnny850807@gmail.com)
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+

--- a/tests/stub_test.py
+++ b/tests/stub_test.py
@@ -1,0 +1,19 @@
+#  Copyright 2020 Waterball (johnny850807@gmail.com)
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+
+from src import stub
+
+
+def test():
+    assert 10 == stub.add(4, 6)


### PR DESCRIPTION
# Changes
- add a basic CI flow with `.drone.yml`
- init the project with a source root